### PR TITLE
Media segments android tv

### DIFF
--- a/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/PlayerActivity.kt
@@ -78,9 +78,17 @@ class PlayerActivity : BasePlayerActivity() {
         // Check if PiP is enabled for the app
         val appOps = getSystemService(APP_OPS_SERVICE) as AppOpsManager?
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            appOps?.unsafeCheckOpNoThrow(AppOpsManager.OPSTR_PICTURE_IN_PICTURE, Process.myUid(), packageName) == AppOpsManager.MODE_ALLOWED
+            appOps?.unsafeCheckOpNoThrow(
+                AppOpsManager.OPSTR_PICTURE_IN_PICTURE,
+                Process.myUid(),
+                packageName,
+            ) == AppOpsManager.MODE_ALLOWED
         } else {
-            appOps?.checkOpNoThrow(AppOpsManager.OPSTR_PICTURE_IN_PICTURE, Process.myUid(), packageName) == AppOpsManager.MODE_ALLOWED
+            appOps?.checkOpNoThrow(
+                AppOpsManager.OPSTR_PICTURE_IN_PICTURE,
+                Process.myUid(),
+                packageName,
+            ) == AppOpsManager.MODE_ALLOWED
         }
     }
 
@@ -157,25 +165,38 @@ class PlayerActivity : BasePlayerActivity() {
 
                             // Skip segment
                             currentMediaSegment = currentSegment
-                            Timber.d("Preferences: %s", appPreferences.getValue(appPreferences.playerMediaSegmentsSkipButtonType))
+                            Timber.d(
+                                "Preferences: %s",
+                                appPreferences.getValue(appPreferences.playerMediaSegmentsSkipButtonType),
+                            )
                             currentSegment?.let { segment ->
-                                if ((
-                                        appPreferences.getValue(appPreferences.playerMediaSegmentsAutoSkip) == Constants.PlayerMediaSegmentsAutoSkip.ALWAYS ||
-                                            (appPreferences.getValue(appPreferences.playerMediaSegmentsAutoSkip) == Constants.PlayerMediaSegmentsAutoSkip.PIP && isInPictureInPictureMode)
-                                        ) &&
-                                    appPreferences.getValue(appPreferences.playerMediaSegmentsAutoSkipType).contains(segment.type.toString())
+                                if (appPreferences.getValue(appPreferences.playerMediaSegmentsAutoSkip) &&
+                                    appPreferences.getValue(appPreferences.playerMediaSegmentsAutoSkipType).contains(segment.type.toString()) &&
+                                    (
+                                        appPreferences.getValue(appPreferences.playerMediaSegmentsAutoSkipWhen) == Constants.PlayerMediaSegmentsAutoSkip.ALWAYS ||
+                                            (
+                                                appPreferences.getValue(appPreferences.playerMediaSegmentsAutoSkipWhen) == Constants.PlayerMediaSegmentsAutoSkip.PIP &&
+                                                    isInPictureInPictureMode
+                                                )
+                                        )
                                 ) {
                                     // Auto skip
                                     viewModel.skipSegment(segment)
-                                } else if (appPreferences.getValue(appPreferences.playerMediaSegmentsSkipButtonType).contains(segment.type.toString())) {
+                                } else if (appPreferences.getValue(appPreferences.playerMediaSegmentsSkipButtonType)
+                                        .contains(segment.type.toString())
+                                ) {
                                     // Skip Button - text
-                                    skipSegmentButton.text = getString(viewModel.getSkipButtonTextStringId(segment))
+                                    skipSegmentButton.text =
+                                        getString(viewModel.getSkipButtonTextStringId(segment))
                                     // Skip Button - visibility
                                     skipSegmentButton.isVisible = !isInPictureInPictureMode
                                     if (skipSegmentButton.isVisible) {
                                         skipButtonTimeoutExpired = false
                                         handler.removeCallbacks(skipButtonTimeout)
-                                        handler.postDelayed(skipButtonTimeout, appPreferences.getValue(appPreferences.playerMediaSegmentsSkipButtonDuration) * 1000)
+                                        handler.postDelayed(
+                                            skipButtonTimeout,
+                                            appPreferences.getValue(appPreferences.playerMediaSegmentsSkipButtonDuration) * 1000,
+                                        )
                                     }
                                     // Skip Button - onClick
                                     skipSegmentButton.setOnClickListener {
@@ -200,7 +221,8 @@ class PlayerActivity : BasePlayerActivity() {
                             // Chapters
                             if (appPreferences.getValue(appPreferences.playerChapterMarkers) && currentChapters != null) {
                                 currentChapters?.let { chapters ->
-                                    val playerControlView = findViewById<PlayerControlView>(R.id.exo_controller)
+                                    val playerControlView =
+                                        findViewById<PlayerControlView>(R.id.exo_controller)
                                     val numOfChapters = chapters.size
                                     playerControlView.setExtraAdGroupMarkers(
                                         LongArray(numOfChapters) { index -> chapters[index].startPosition },
@@ -234,7 +256,8 @@ class PlayerActivity : BasePlayerActivity() {
                                 if (appPreferences.getValue(appPreferences.playerPipGesture)) {
                                     try {
                                         setPictureInPictureParams(pipParams(event.isPlaying))
-                                    } catch (_: IllegalArgumentException) { }
+                                    } catch (_: IllegalArgumentException) {
+                                    }
                                 }
                             }
                         }
@@ -323,7 +346,9 @@ class PlayerActivity : BasePlayerActivity() {
 
         binding.playerView.setControllerVisibilityListener(
             PlayerView.ControllerVisibilityListener { visibility ->
-                if (appPreferences.getValue(appPreferences.playerMediaSegmentsSkipButtonType).contains(currentMediaSegment?.type.toString()) && skipButtonTimeoutExpired) {
+                if (appPreferences.getValue(appPreferences.playerMediaSegmentsSkipButtonType)
+                        .contains(currentMediaSegment?.type.toString()) && skipButtonTimeoutExpired
+                ) {
                     skipSegmentButton.visibility = visibility
                 }
             },
@@ -373,7 +398,8 @@ class PlayerActivity : BasePlayerActivity() {
         }
 
         val sourceRectHint = if (displayAspectRatio < aspectRatio!!) {
-            val space = ((binding.playerView.height - (binding.playerView.width.toFloat() / aspectRatio.toFloat())) / 2).toInt()
+            val space =
+                ((binding.playerView.height - (binding.playerView.width.toFloat() / aspectRatio.toFloat())) / 2).toInt()
             Rect(
                 0,
                 space,
@@ -381,7 +407,8 @@ class PlayerActivity : BasePlayerActivity() {
                 (binding.playerView.width.toFloat() / aspectRatio.toFloat()).toInt() + space,
             )
         } else {
-            val space = ((binding.playerView.width - (binding.playerView.height.toFloat() * aspectRatio.toFloat())) / 2).toInt()
+            val space =
+                ((binding.playerView.width - (binding.playerView.height.toFloat() * aspectRatio.toFloat())) / 2).toInt()
             Rect(
                 space,
                 0,
@@ -408,7 +435,8 @@ class PlayerActivity : BasePlayerActivity() {
 
         try {
             enterPictureInPictureMode(pipParams())
-        } catch (_: IllegalArgumentException) { }
+        } catch (_: IllegalArgumentException) {
+        }
     }
 
     override fun onPictureInPictureModeChanged(
@@ -429,20 +457,22 @@ class PlayerActivity : BasePlayerActivity() {
                     screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
                 }
             }
+
             false -> {
                 binding.playerView.useController = true
                 playerGestureHelper?.updateZoomMode(wasZoom)
 
                 // Override auto brightness
                 window.attributes = window.attributes.apply {
-                    screenBrightness = if (appPreferences.getValue(appPreferences.playerGesturesBrightnessRemember)) {
-                        appPreferences.getValue(appPreferences.playerBrightness)
-                    } else {
-                        Settings.System.getInt(
-                            contentResolver,
-                            Settings.System.SCREEN_BRIGHTNESS,
-                        ).toFloat() / 255
-                    }
+                    screenBrightness =
+                        if (appPreferences.getValue(appPreferences.playerGesturesBrightnessRemember)) {
+                            appPreferences.getValue(appPreferences.playerBrightness)
+                        } else {
+                            Settings.System.getInt(
+                                contentResolver,
+                                Settings.System.SCREEN_BRIGHTNESS,
+                            ).toFloat() / 255
+                        }
                 }
             }
         }

--- a/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/settings/components/SettingsMultiSelectDialog.kt
+++ b/app/phone/src/main/java/dev/jdtech/jellyfin/presentation/settings/components/SettingsMultiSelectDialog.kt
@@ -46,6 +46,7 @@ fun SettingsMultiSelectDialog(
     onDismissRequest: () -> Unit,
 ) {
     val lazyListState = rememberLazyListState()
+
     val isAtTop by remember {
         derivedStateOf {
             lazyListState.firstVisibleItemIndex == 0 && lazyListState.firstVisibleItemScrollOffset == 0

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/settings/SettingsSubScreen.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/settings/SettingsSubScreen.kt
@@ -26,13 +26,15 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
-import dev.jdtech.jellyfin.presentation.settings.components.SettingsDetailsCard
+import dev.jdtech.jellyfin.presentation.settings.components.SettingsDetailsMultiSelectCard
+import dev.jdtech.jellyfin.presentation.settings.components.SettingsDetailsSelectCard
 import dev.jdtech.jellyfin.presentation.settings.components.SettingsGroupCard
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
 import dev.jdtech.jellyfin.presentation.theme.spacings
 import dev.jdtech.jellyfin.settings.domain.models.Preference
 import dev.jdtech.jellyfin.settings.presentation.enums.DeviceType
 import dev.jdtech.jellyfin.settings.presentation.models.PreferenceGroup
+import dev.jdtech.jellyfin.settings.presentation.models.PreferenceMultiSelect
 import dev.jdtech.jellyfin.settings.presentation.models.PreferenceSelect
 import dev.jdtech.jellyfin.settings.presentation.settings.SettingsAction
 import dev.jdtech.jellyfin.settings.presentation.settings.SettingsEvent
@@ -98,6 +100,7 @@ private fun SettingsSubScreenLayout(
     var focusedPreference by remember(state.preferenceGroups.isNotEmpty()) {
         mutableStateOf(state.preferenceGroups.firstOrNull()?.preferences?.firstOrNull())
     }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -142,20 +145,39 @@ private fun SettingsSubScreenLayout(
             Box(
                 modifier = Modifier.weight(2f),
             ) {
-                (focusedPreference as? PreferenceSelect)?.let { preference ->
-                    SettingsDetailsCard(
-                        preference = preference,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(bottom = MaterialTheme.spacings.large),
-                        onUpdate = { value ->
-                            onAction(
-                                SettingsAction.OnUpdate(
-                                    preference.copy(value = value),
-                                ),
+                focusedPreference?.let { preference ->
+                    when (preference) {
+                        is PreferenceSelect -> {
+                            SettingsDetailsSelectCard(
+                                preference = preference,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(bottom = MaterialTheme.spacings.large),
+                                onUpdate = { value ->
+                                    onAction(
+                                        SettingsAction.OnUpdate(
+                                            preference.copy(value = value),
+                                        ),
+                                    )
+                                },
                             )
-                        },
-                    )
+                        }
+                        is PreferenceMultiSelect -> {
+                            SettingsDetailsMultiSelectCard(
+                                preference = preference,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(bottom = MaterialTheme.spacings.large),
+                                onUpdate = { value ->
+                                    onAction(
+                                        SettingsAction.OnUpdate(
+                                            preference.copy(value = value),
+                                        ),
+                                    )
+                                },
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/settings/components/SettingsDetailsMultiSelectCard.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/settings/components/SettingsDetailsMultiSelectCard.kt
@@ -13,7 +13,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -22,38 +25,37 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Border
+import androidx.tv.material3.Checkbox
 import androidx.tv.material3.ClickableSurfaceDefaults
 import androidx.tv.material3.ClickableSurfaceScale
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.RadioButton
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
 import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
 import dev.jdtech.jellyfin.presentation.theme.spacings
 import dev.jdtech.jellyfin.settings.domain.models.Preference
-import dev.jdtech.jellyfin.settings.presentation.models.PreferenceSelect
-import dev.jdtech.jellyfin.core.R as CoreR
+import dev.jdtech.jellyfin.settings.presentation.models.PreferenceMultiSelect
 import dev.jdtech.jellyfin.settings.R as SettingsR
 
 @Composable
-fun SettingsDetailsSelectCard(
-    preference: PreferenceSelect,
-    onUpdate: (value: String?) -> Unit,
+fun SettingsDetailsMultiSelectCard(
+    preference: PreferenceMultiSelect,
+    onUpdate: (value: Set<String>?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val optionValues = stringArrayResource(preference.optionValues)
     val optionNames = stringArrayResource(preference.options)
-    val notSetString = stringResource(CoreR.string.not_set)
 
     val options = remember(preference.nameStringResource) {
         val options = mutableListOf<Pair<String?, String>>()
 
-        if (preference.optionsIncludeNull) {
-            options.add(Pair(null, notSetString))
-        }
         options.addAll(optionValues.zip(optionNames))
 
         options
+    }
+
+    var selectedOptions by remember {
+        mutableStateOf(preference.value?.toSet() ?: emptySet())
     }
 
     Surface(
@@ -76,10 +78,18 @@ fun SettingsDetailsSelectCard(
                 contentPadding = PaddingValues(vertical = MaterialTheme.spacings.extraSmall),
             ) {
                 items(options) { option ->
-                    SettingsSelectDialogItem(
+                    SettingsMultiSelectDialogItem(
                         option = option,
-                        isSelected = option.first == preference.value,
-                        onSelect = onUpdate,
+                        checked = selectedOptions.contains(option.first),
+                        onCheckedChange = { key ->
+                            selectedOptions = if (selectedOptions.contains(key)) {
+                                selectedOptions - setOfNotNull(key)
+                            } else {
+                                selectedOptions + listOfNotNull(key)
+                            }
+
+                            onUpdate(selectedOptions.ifEmpty { emptySet() })
+                        },
                         isEnabled = preference.enabled,
                     )
                 }
@@ -89,14 +99,14 @@ fun SettingsDetailsSelectCard(
 }
 
 @Composable
-private fun SettingsSelectDialogItem(
+private fun SettingsMultiSelectDialogItem(
     option: Pair<String?, String>,
-    isSelected: Boolean,
-    onSelect: (String?) -> Unit,
+    checked: Boolean,
+    onCheckedChange: (String?) -> Unit,
     isEnabled: Boolean = true,
 ) {
     Surface(
-        onClick = { onSelect(option.first) },
+        onClick = { onCheckedChange(option.first) },
         shape = ClickableSurfaceDefaults.shape(shape = RoundedCornerShape(4.dp)),
         colors = ClickableSurfaceDefaults.colors(
             containerColor = Color.Transparent,
@@ -117,9 +127,9 @@ private fun SettingsSelectDialogItem(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(MaterialTheme.spacings.extraSmall),
         ) {
-            RadioButton(
-                selected = isSelected,
-                onClick = null,
+            Checkbox(
+                checked = checked,
+                onCheckedChange = { _ -> onCheckedChange(option.first) },
                 enabled = isEnabled,
             )
             Spacer(modifier = Modifier.width(MaterialTheme.spacings.medium))
@@ -132,12 +142,12 @@ private fun SettingsSelectDialogItem(
 @Composable
 private fun SettingsDetailCardPreview() {
     FindroidTheme {
-        SettingsDetailsSelectCard(
-            preference = PreferenceSelect(
+        SettingsDetailsMultiSelectCard(
+            preference = PreferenceMultiSelect(
                 nameStringResource = SettingsR.string.settings_preferred_audio_language,
-                backendPreference = Preference("", ""),
-                options = SettingsR.array.languages,
-                optionValues = SettingsR.array.languages_values,
+                backendPreference = Preference("", emptySet()),
+                options = SettingsR.array.media_segments_type,
+                optionValues = SettingsR.array.media_segments_type_values,
             ),
             onUpdate = {},
         )

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/settings/components/SettingsGroupCard.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/settings/components/SettingsGroupCard.kt
@@ -23,6 +23,7 @@ import dev.jdtech.jellyfin.presentation.theme.spacings
 import dev.jdtech.jellyfin.settings.presentation.models.Preference
 import dev.jdtech.jellyfin.settings.presentation.models.PreferenceCategory
 import dev.jdtech.jellyfin.settings.presentation.models.PreferenceGroup
+import dev.jdtech.jellyfin.settings.presentation.models.PreferenceMultiSelect
 import dev.jdtech.jellyfin.settings.presentation.models.PreferenceSelect
 import dev.jdtech.jellyfin.settings.presentation.models.PreferenceSwitch
 import dev.jdtech.jellyfin.settings.presentation.settings.SettingsAction
@@ -80,6 +81,15 @@ fun SettingsGroupCard(
                                 },
                         )
                         is PreferenceSelect -> SettingsSelectCard(
+                            preference = preference,
+                            onClick = { },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .onFocusChanged {
+                                    onFocusChange(it, preference)
+                                },
+                        )
+                        is PreferenceMultiSelect -> SettingsMultiSelectCard(
                             preference = preference,
                             onClick = { },
                             modifier = Modifier

--- a/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/settings/components/SettingsMultiSelectCard.kt
+++ b/app/tv/src/main/java/dev/jdtech/jellyfin/presentation/settings/components/SettingsMultiSelectCard.kt
@@ -1,0 +1,129 @@
+package dev.jdtech.jellyfin.presentation.settings.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Border
+import androidx.tv.material3.ClickableSurfaceDefaults
+import androidx.tv.material3.ClickableSurfaceScale
+import androidx.tv.material3.Icon
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Surface
+import androidx.tv.material3.Text
+import dev.jdtech.jellyfin.presentation.theme.FindroidTheme
+import dev.jdtech.jellyfin.presentation.theme.spacings
+import dev.jdtech.jellyfin.settings.domain.models.Preference
+import dev.jdtech.jellyfin.settings.presentation.models.PreferenceMultiSelect
+import dev.jdtech.jellyfin.core.R as CoreR
+import dev.jdtech.jellyfin.settings.R as SettingsR
+
+@Composable
+fun SettingsMultiSelectCard(
+    preference: PreferenceMultiSelect,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    val optionValues = stringArrayResource(preference.optionValues)
+    val optionNames = stringArrayResource(preference.options)
+    val noneString = stringResource(CoreR.string.none)
+
+    val options = remember(preference.nameStringResource) {
+        val options = mutableListOf<Pair<String?, String>>()
+
+        options.addAll(optionValues.zip(optionNames))
+
+        options
+    }
+
+    val optionsMap = remember(options) {
+        options.toMap()
+    }
+
+    Surface(
+        onClick = onClick,
+        enabled = preference.enabled,
+        shape = ClickableSurfaceDefaults.shape(shape = RoundedCornerShape(10.dp)),
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = MaterialTheme.colorScheme.surface,
+            focusedContainerColor = MaterialTheme.colorScheme.surface,
+            disabledContainerColor = MaterialTheme.colorScheme.surface,
+        ),
+        border = ClickableSurfaceDefaults.border(
+            focusedBorder = Border(
+                BorderStroke(
+                    4.dp,
+                    Color.White,
+                ),
+                shape = RoundedCornerShape(10.dp),
+            ),
+        ),
+        scale = ClickableSurfaceScale.None,
+        modifier = modifier
+            .fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(MaterialTheme.spacings.default),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (preference.iconDrawableId != null) {
+                Icon(
+                    painter = painterResource(id = preference.iconDrawableId!!),
+                    contentDescription = null,
+                )
+                Spacer(modifier = Modifier.width(24.dp))
+            }
+
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = stringResource(id = preference.nameStringResource),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+
+                Spacer(modifier = Modifier.height(MaterialTheme.spacings.extraSmall))
+                Text(
+                    text = preference.value
+                        .orEmpty()
+                        .map { key -> optionsMap[key] }
+                        .joinToString(", ")
+                        .ifEmpty { noneString },
+                    style = MaterialTheme.typography.labelMedium,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SettingsMultiSelectCardPreview() {
+    FindroidTheme {
+        SettingsMultiSelectCard(
+            preference = PreferenceMultiSelect(
+                nameStringResource = SettingsR.string.settings_preferred_audio_language,
+                iconDrawableId = SettingsR.drawable.ic_speaker,
+                backendPreference = Preference("", emptySet()),
+                options = SettingsR.array.languages,
+                optionValues = SettingsR.array.languages_values,
+            ),
+            onClick = {},
+        )
+    }
+}

--- a/player/video/src/main/java/dev/jdtech/jellyfin/viewmodels/PlayerActivityViewModel.kt
+++ b/player/video/src/main/java/dev/jdtech/jellyfin/viewmodels/PlayerActivityViewModel.kt
@@ -28,7 +28,6 @@ import dev.jdtech.jellyfin.mpv.MPVPlayer
 import dev.jdtech.jellyfin.player.video.R
 import dev.jdtech.jellyfin.repository.JellyfinRepository
 import dev.jdtech.jellyfin.settings.domain.AppPreferences
-import dev.jdtech.jellyfin.settings.domain.Constants
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -244,7 +243,7 @@ constructor(
             }
         }
         if (appPreferences.getValue(appPreferences.playerMediaSegmentsSkipButton) ||
-            appPreferences.getValue(appPreferences.playerMediaSegmentsAutoSkip) != Constants.PlayerMediaSegmentsAutoSkip.NEVER
+            appPreferences.getValue(appPreferences.playerMediaSegmentsAutoSkip)
         ) {
             handler.post(segmentCheckRunnable)
         }

--- a/settings/src/main/java/dev/jdtech/jellyfin/settings/domain/AppPreferences.kt
+++ b/settings/src/main/java/dev/jdtech/jellyfin/settings/domain/AppPreferences.kt
@@ -54,7 +54,8 @@ constructor(
     val playerMediaSegmentsSkipButton get() = Preference("pref_player_media_segments_skip_button", true)
     val playerMediaSegmentsSkipButtonType get() = Preference("pref_player_media_segments_skip_button_type", setOf("INTRO", "OUTRO"))
     val playerMediaSegmentsSkipButtonDuration get() = Preference("pref_player_media_segments_skip_button_duration", Constants.PLAYER_MEDIA_SEGMENTS_DEFAULT_SKIP_BUTTON_DURATION)
-    val playerMediaSegmentsAutoSkip get() = Preference("pref_player_media_segments_auto_skip", Constants.PlayerMediaSegmentsAutoSkip.NEVER)
+    val playerMediaSegmentsAutoSkipWhen get() = Preference("pref_player_media_segments_auto_skip_mobile", Constants.PlayerMediaSegmentsAutoSkip.ALWAYS)
+    val playerMediaSegmentsAutoSkip get() = Preference("pref_player_media_segments_auto_skip_tv", false)
     val playerMediaSegmentsAutoSkipType get() = Preference("pref_player_media_segments_auto_skip_type", setOf("INTRO", "OUTRO"))
     val playerMediaSegmentsNextEpisodeThreshold get() = Preference("pref_player_media_segments_next_episode_threshold", Constants.PLAYER_MEDIA_SEGMENTS_DEFAULT_NEXT_EPISODE_THRESHOLD)
 

--- a/settings/src/main/java/dev/jdtech/jellyfin/settings/domain/Constants.kt
+++ b/settings/src/main/java/dev/jdtech/jellyfin/settings/domain/Constants.kt
@@ -7,7 +7,6 @@ object Constants {
     object PlayerMediaSegmentsAutoSkip {
         const val ALWAYS = "always"
         const val PIP = "pip"
-        const val NEVER = "never"
     }
 
     // Network

--- a/settings/src/main/java/dev/jdtech/jellyfin/settings/presentation/settings/SettingsViewModel.kt
+++ b/settings/src/main/java/dev/jdtech/jellyfin/settings/presentation/settings/SettingsViewModel.kt
@@ -44,6 +44,7 @@ constructor(
                     descriptionStringRes = R.string.offline_mode_summary,
                     iconDrawableId = R.drawable.ic_server_off,
                     enabled = false,
+                    supportedDeviceTypes = listOf(DeviceType.PHONE),
                     backendPreference = appPreferences.offlineMode,
                 ),
             ),
@@ -316,14 +317,22 @@ constructor(
                                     backendPreference = appPreferences.playerMediaSegmentsSkipButtonDuration,
                                     suffixRes = R.string.seconds,
                                 ),
-                                PreferenceSelect(
+                                PreferenceSwitch(
                                     nameStringResource = R.string.pref_player_media_segments_auto_skip,
+                                    descriptionStringRes = R.string.pref_player_media_segments_auto_skip_summary,
                                     backendPreference = appPreferences.playerMediaSegmentsAutoSkip,
+                                ),
+                                PreferenceSelect(
+                                    nameStringResource = R.string.pref_player_media_segments_auto_skip_when,
+                                    dependencies = listOf(appPreferences.playerMediaSegmentsAutoSkip),
+                                    supportedDeviceTypes = listOf(DeviceType.PHONE),
+                                    backendPreference = appPreferences.playerMediaSegmentsAutoSkipWhen,
                                     options = R.array.media_segments_auto_skip,
                                     optionValues = R.array.media_segments_auto_skip_values,
                                 ),
                                 PreferenceMultiSelect(
                                     nameStringResource = R.string.pref_player_media_segments_auto_skip_type,
+                                    dependencies = listOf(appPreferences.playerMediaSegmentsAutoSkip),
                                     backendPreference = appPreferences.playerMediaSegmentsAutoSkipType,
                                     options = R.array.media_segments_type,
                                     optionValues = R.array.media_segments_type_values,

--- a/settings/src/main/res/values/string_arrays.xml
+++ b/settings/src/main/res/values/string_arrays.xml
@@ -24,12 +24,10 @@
         <item>opensles</item>
     </string-array>
     <string-array name="media_segments_auto_skip">
-        <item>@string/media_segments_auto_skip_never</item>
         <item>@string/media_segments_auto_skip_pip</item>
         <item>@string/media_segments_auto_skip_always</item>
     </string-array>
     <string-array name="media_segments_auto_skip_values">
-        <item>never</item>
         <item>pip</item>
         <item>always</item>
     </string-array>

--- a/settings/src/main/res/values/strings.xml
+++ b/settings/src/main/res/values/strings.xml
@@ -87,9 +87,10 @@
     <string name="pref_player_media_segments_skip_button_type">Segment type to display the skip button</string>
     <string name="pref_player_media_segments_skip_button_duration">Display skip button for</string>
     <string name="pref_player_media_segments_auto_skip">Auto skip</string>
+    <string name="pref_player_media_segments_auto_skip_summary">Enable automatic skipping for chosen segment types</string>
+    <string name="pref_player_media_segments_auto_skip_when">When to auto skip</string>
     <string name="pref_player_media_segments_auto_skip_type">Segment type to auto skip</string>
     <string name="pref_player_media_segments_next_episode_threshold">Skip to next episode threshold</string>
-    <string name="media_segments_auto_skip_never">never</string>
     <string name="media_segments_auto_skip_pip">only in pip mode</string>
     <string name="media_segments_auto_skip_always">always</string>
     <string name="media_segments_type_unknown">Others</string>


### PR DESCRIPTION
## Summary by Sourcery

Add media-segment skip controls and preferences to the Android TV app, introduce new settings UI components for multi-select preferences, and refine the shared auto-skip configuration.

New Features:
- Display a skip button in the Android TV player's Compose UI when a media segment is present
- Add a "When to auto skip" setting and multi-select segment type option to both phone and TV settings

Enhancements:
- Separate media segment auto-skip preferences for mobile and TV, and remove the “never” option
- Introduce TV-specific select and multi-select cards for settings details
- Refactor player skip logic to streamline auto-skip and skip-button conditions

Chores:
- Adjust Kotlin code formatting and update string and array resources for the new preferences